### PR TITLE
Fix ubuntu install by using .profile and .bash_profile instead of .bashrc for PATH variable

### DIFF
--- a/roles/payara/tasks/main.yml
+++ b/roles/payara/tasks/main.yml
@@ -43,11 +43,23 @@
     owner: root
     group: root
     mode: 0775
+     
+- name: 'Check if .bash_profile exists'
+  stat:
+    path: /home/glassfish/.bash_profile
+  register: bashProfileResult
 
-- name: 'Add path to payara executable to PATH variable'
+- name: 'Add path to payara executable to PATH variable in .bash_profile'
   lineinfile:
-    path: /home/glassfish/.bashrc
+    path: /home/glassfish/.bash_profile
     line: 'export PATH=$HOME/{{ payara_directory }}/bin:$PATH'
+  when: bashProfileResult.stat.exists is defined and bashProfileResult.stat.exists == true
+
+- name: 'Add path to payara executable to PATH variable in .profile'
+  lineinfile:
+    path: /home/glassfish/.profile
+    line: 'export PATH=$HOME/{{ payara_directory }}/bin:$PATH'
+  when: bashProfileResult.stat.exists is defined and bashProfileResult.stat.exists == false
 
 - name: 'Check payara package'
   stat:


### PR DESCRIPTION
Ubuntu could not use the `asadmin` command due to the PATH variable not being set correctly. This was fixed by instead using `.profile` instead of `.bashrc`, but then this broke CentOS since CentOS uses `.bash_profile` instead of `.profile`. Additionally, I think PATH is orginally set in `.profile`/`.bash_profile` and this is the correct place for setting environment variables instead of `.bashrc`.

Therefore, first check if `.bash_profile` exists and set PATH variable in that, otherwise use `.profile`. I tested this on fresh VMs and it worked on both CentOS 7 and Ubuntu Xenial.