### PR TITLE
Fix Playbook for Ubuntu 20 (DataGateway)

### DIFF
--- a/roles/mariadb/vars/debian-20.yml
+++ b/roles/mariadb/vars/debian-20.yml
@@ -2,8 +2,8 @@
 mariadb_daemon: mysql
 mariadb_config_dir: /etc/mysql/conf.d
 mariadb_pkgs:
-  - mariadb-server-10.3
   - mariadb-client-10.3
+  - mariadb-server-10.3
   - mariadb-server
   - mariadb-client
   - python3-mysqldb


### PR DESCRIPTION
Just swapping round the mariadb dependencies to fix an error found on DataGateway's CI. This change only affects systems which run the playbook on Ubuntu 20.

This fix works, as seen on DataGateway API CI (https://github.com/ral-facilities/datagateway-api/runs/3999366503?check_suite_focus=true) and DataGateway CI (https://github.com/ral-facilities/datagateway/runs/3999484545?check_suite_focus=true).