### PR TITLE
icat.server 6.1.0, icat.lucene 3.0.0

### DIFF
--- a/icat_server_dev_hosts.yml
+++ b/icat_server_dev_hosts.yml
@@ -12,4 +12,5 @@
     - role: authn_simple
     - role: authn_db
     - role: icat_lucene
+    - role: icat_server
     - role: dev_common

--- a/roles/dev_common/templates/settings.xml.j2
+++ b/roles/dev_common/templates/settings.xml.j2
@@ -7,7 +7,8 @@
          <properties>
              <serverUrl>{{ icat_url }}</serverUrl>
              {% if lucene_url is defined and lucene_url %}
-             <luceneUrl>{{ lucene_url }}</luceneUrl>
+             <searchEngine>LUCENE</searchEngine>
+             <searchUrls>{{ lucene_url }}</searchUrls>
              {% endif %}
              <javax.net.ssl.trustStore>{{ payara_domain_dir }}/config/cacerts.jks</javax.net.ssl.trustStore>
              <containerHome>{{ payara_dir }}</containerHome>

--- a/roles/icat_lucene/defaults/main.yml
+++ b/roles/icat_lucene/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 
-icat_lucene_version: '3.0.0-SNAPSHOT'
+icat_lucene_version: '3.0.0'
 icat_lucene_data_dir: 'data/lucene'

--- a/roles/icat_lucene/defaults/main.yml
+++ b/roles/icat_lucene/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 
-icat_lucene_version: '2.0.2'
+icat_lucene_version: '3.0.0-SNAPSHOT'
 icat_lucene_data_dir: 'data/lucene'

--- a/roles/icat_lucene/templates/run.properties.j2
+++ b/roles/icat_lucene/templates/run.properties.j2
@@ -5,7 +5,9 @@ directory = /home/{{ payara_user }}/{{ icat_lucene_data_dir }}
 commitSeconds = 5
 ip = 127.0.0.1/32 0:0:0:0:0:0:0:1/128 10.0.0.1/8 {{ ansible_default_ipv4.address }}/32
 {% if icat_lucene_version is version('3.0.0', '>=') %}
-maxShardSize   = 2147483648
+maxShardSize   = 2147483519
 aggregateFiles = false
 facetFields    = datafileFormat.name instrument.name sample.type.name stringValue technique.name type.name
+units          = J: eV 1.602176634e-19; \u2103: celsius, degC; K: kelvin
+maxSearchTimeSeconds = 5
 {% endif %}

--- a/roles/icat_server/defaults/main.yml
+++ b/roles/icat_server/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-icat_server_version: '6.0.1'
+icat_server_version: '6.1.0-SNAPSHOT'
 icat_server_rootUserNames: "{% if ansible_local.local.instantiations.authn_simple is defined and ansible_local.local.instantiations.authn_simple == 'true' %}simple/root {% endif %}{% if ansible_local.local.instantiations.authn_db is defined and ansible_local.local.instantiations.authn_db == 'true' %}db/root {% endif %}"
 icat_server_maxEntities: "10000"
 icat_server_authn_list: "{% if ansible_local.local.instantiations.authn_simple is defined and ansible_local.local.instantiations.authn_simple == 'true' %}simple {% endif %}{% if ansible_local.local.instantiations.authn_db is defined and ansible_local.local.instantiations.authn_db == 'true' %}db {% endif %}{% if ansible_local.local.instantiations.authn_anon is defined and ansible_local.local.instantiations.authn_anon == 'true' %}anon {% endif %}{% if ansible_local.local.instantiations.authn_ldap is defined and ansible_local.local.instantiations.authn_ldap == 'true' %}ldap {% endif %}{% if ansible_local.local.instantiations.authn_ip_clf is defined and ansible_local.local.instantiations.authn_ip_clf == 'true' %}ip_clf {% endif %}{% if ansible_local.local.instantiations.authn_uows_clf is defined and ansible_local.local.instantiations.authn_uows_clf == 'true' %}uows_clf {% endif %}"

--- a/roles/icat_server/defaults/main.yml
+++ b/roles/icat_server/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-icat_server_version: '6.1.0-SNAPSHOT'
+icat_server_version: '6.1.0'
 icat_server_rootUserNames: "{% if ansible_local.local.instantiations.authn_simple is defined and ansible_local.local.instantiations.authn_simple == 'true' %}simple/root {% endif %}{% if ansible_local.local.instantiations.authn_db is defined and ansible_local.local.instantiations.authn_db == 'true' %}db/root {% endif %}"
 icat_server_maxEntities: "10000"
 icat_server_authn_list: "{% if ansible_local.local.instantiations.authn_simple is defined and ansible_local.local.instantiations.authn_simple == 'true' %}simple {% endif %}{% if ansible_local.local.instantiations.authn_db is defined and ansible_local.local.instantiations.authn_db == 'true' %}db {% endif %}{% if ansible_local.local.instantiations.authn_anon is defined and ansible_local.local.instantiations.authn_anon == 'true' %}anon {% endif %}{% if ansible_local.local.instantiations.authn_ldap is defined and ansible_local.local.instantiations.authn_ldap == 'true' %}ldap {% endif %}{% if ansible_local.local.instantiations.authn_ip_clf is defined and ansible_local.local.instantiations.authn_ip_clf == 'true' %}ip_clf {% endif %}{% if ansible_local.local.instantiations.authn_uows_clf is defined and ansible_local.local.instantiations.authn_uows_clf == 'true' %}uows_clf {% endif %}"

--- a/roles/icat_server/defaults/main.yml
+++ b/roles/icat_server/defaults/main.yml
@@ -7,3 +7,4 @@ icat_server_authn_list: "{% if ansible_local.local.instantiations.authn_simple i
 icat_server_authn_ldap_admin: "true"
 icat_server_lucene_populateBlockSize: "1000"
 icat_server_install_db_triggers: true
+icat_server_search_dir: /home/{{ payara_user }}/data/search

--- a/roles/icat_server/tasks/main.yml
+++ b/roles/icat_server/tasks/main.yml
@@ -91,6 +91,14 @@
   notify:
     - "icat_server-handler"
 
+- name: "Create icat_server search queues directory"
+  file:
+    path: "{{ icat_server_search_dir }}"
+    state: directory
+    owner: "{{ payara_user }}"
+    group: "{{ payara_user_group }}"
+    mode: 0775
+
 - name: "Configure icat_server logback.xml"
   copy:
     src: files/logback.xml

--- a/roles/icat_server/templates/run.properties.j2
+++ b/roles/icat_server/templates/run.properties.j2
@@ -85,7 +85,7 @@ search.populateBlockSize = {{ icat_server_lucene_populateBlockSize }}
 # If search.searchBlockSize > maxIdsInQuery, then multiple auth checks may be needed for a single search
 # The optimal value depends on how likely a user's auth request fails: larger values are more efficient when rejection is more likely
 search.searchBlockSize = 1000
-search.directory = /home/{{ payara_user }}/{{ icat_lucene_data_dir }}
+search.directory = {{ icat_server_search_dir }}
 search.backlogHandlerIntervalSeconds = 60
 search.enqueuedRequestIntervalSeconds = 5
 search.aggregateFilesIntervalSeconds = 3600


### PR DESCRIPTION
Now that these versions are released, I've removed SNAPSHOT from the default versions and updated the icat.lucene run.properties to include all the settings that the CI should expect (i.e. that same settings as are in https://github.com/icatproject/icat.lucene/blob/master/src/main/resources/run.properties). A test involving unit conversion is currentlyfailing on the icat.server CI, I'm hoping this will fix that.

Is there anything else to do before this can be merged?